### PR TITLE
Fix README instructions for run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,55 +31,63 @@ The analysis expects your experimental data to be provided as **MATLAB `.mat` fi
 
 **Preparing your data:** Make sure you have your wall pressure data saved in a `.mat` file (or multiple files, if you have several runs). Take note of the file path to this data on your computer. If your data is currently in another format (CSV, text, etc.), you may need to convert it to `.mat` or adapt the code (this toolkit is primarily set up for `.mat` files).
 
-**Configuring the file path:** Open the file `run.py` in a text editor. Inside `run.py`, there will be a variable or line where the input data file path is defined (for example, it might look like `data_file = "data/sample_pressure_signal.mat"`). You need to **modify this path** to point to your own data file. For example:
+**Configuring the file paths:** Open the script `src/run.py` in a text editor.
+At the top of the file you will find two variables defining the locations of
+the wall-pressure and free-stream pressure data:
 
 ```python
-# Inside run.py, find where the input file path is set and update it:
-data_file = "data/sample_wall_pressure.mat"  # Example path in the repository
+# Inside src/run.py
+WALL_PRESSURE_MAT = "data/wallpressure_booman_Pa.mat"
+FREESTREAM_PRESSURE_MAT = "data/booman_wallpressure_fspressure_650sec_40khz.mat"
+```
 
-# Change it to the path of your .mat file, for instance:
-data_file = "C:/Users/YourName/Experiment/my_pressure_data.mat"
+Replace these with the paths to your own `.mat` files, for example:
+
+```python
+WALL_PRESSURE_MAT = "C:/Users/YourName/Experiment/wall.mat"
+FREESTREAM_PRESSURE_MAT = "C:/Users/YourName/Experiment/free_stream.mat"
 ```
 
 ## Usage
 
-Once you have installed the package and set up your input data path in `run.py`, you can run the analysis. The usage steps are outlined below:
+Once you have installed the package and set up your input data paths in `src/run.py`, you can run the analysis. The usage steps are outlined below:
 
 1. **Install the package** â€“ (If you haven't done this yet, see the [Installation](#installation) section above to set up `ProcessWallPressureSignal` using pip.)
 2. **Prepare your input data** â€“ Ensure you have your wall pressure data available in a `.mat` file. For example, `my_experiment.mat` containing the pressure time series from your test. Place it in a convenient location or within the repository folder (or note its full file path).
-3. **Update the `run.py` file** â€“ Edit the repository's `run.py` script to point to your `.mat` file, as described above.
+3. **Update the `src/run.py` file** â€“ Edit the script to point to your `.mat` files, as described above.
 4. **Run the analysis script** â€“ In the terminal:
    ```bash
-   python run.py
+   python src/run.py
    ```
 5. **View the results** â€“ Check console output and any saved figures or processed data files in the repository directory.
 
 ## Example Scenario
 
-Suppose you conducted an experiment and recorded wall pressure fluctuations, saving the data in a file called `pressure_test.mat`. To analyze this data with ProcessWallPressureSignal:
+Suppose you conducted an experiment and recorded wall pressure fluctuations, saving the data in files `pressure_test.mat` and `pressure_test_fs.mat`. To analyze this data with ProcessWallPressureSignal:
 
-- After installation, open `run.py` and set:
+- After installation, open `src/run.py` and set:
   ```python
-  data_file = "pressure_test.mat"
+  WALL_PRESSURE_MAT = "pressure_test.mat"
+  FREESTREAM_PRESSURE_MAT = "pressure_test_fs.mat"
   ```
 - Run:
   ```bash
-  python run.py
+  python src/run.py
   ```
 - Review the output (e.g., `spectrum.png` or `pressure_test_processed.mat`) saved in the repository folder.
 
 ## Technical Details (Beginner-Friendly)
 
 - **Language and Libraries:** Written in Python, using libraries such as **NumPy**, **SciPy** (for .mat file handling), **Matplotlib** (for plotting), and other dependencies installed automatically via pip.
-- **Editable vs Installed Usage:** Editable mode (`pip install -e .`) lets you modify code and see changes immediately. A standard install also allows running `run.py` directly.
-- **Modifying the Analysis:** You can customize `run.py` or module code to adjust filters, add calculations, or change output formats.
+- **Editable vs Installed Usage:** Editable mode (`pip install -e .`) lets you modify code and see changes immediately. A standard install also allows running `src/run.py` directly.
+- **Modifying the Analysis:** You can customize `src/run.py` or module code to adjust filters, add calculations, or change output formats.
 
 ## Troubleshooting
 
 - **Module not found:** Ensure you ran `pip install .` in the repository root.
 - **pip/python not recognized:** Use `python3`/`pip3` or add Python to your PATH.
 - **.mat load errors:** Verify your file path and MATLAB version; SciPy supports most standard formats.
-- **No output:** Check that `run.py` points to the correct path and prints status messages.
+- **No output:** Check that `src/run.py` points to the correct path and prints status messages.
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary
- update README to reference `src/run.py`
- clarify which path variables to edit for wall and free-stream `.mat` files
- update example usage commands

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*