### PR TITLE
Refactor to Torch tensors with updated tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         "seaborn",
         "icecream",
         "scienceplots",
+        "torch",
     ],
     # optional: include_package_data=True, and MANIFEST.in to include data files if needed
 )

--- a/src/i_o.py
+++ b/src/i_o.py
@@ -1,17 +1,17 @@
-import numpy as np
+import torch
 import scipy.io as sio
 
 def load_stan_wallpressure(path, var_name="wall_pressure_fluc_Pa"):
     """Load frequency and pressure from a .mat file."""
     data = sio.loadmat(path)
-    fs = np.ravel(data.get("fs_pressure_fluc_Pa", data.get("fs", None)))
-    p  = np.ravel(data.get(var_name))
+    fs = torch.tensor(data.get("fs_pressure_fluc_Pa", data.get("fs", None))).ravel()
+    p  = torch.tensor(data.get(var_name)).ravel()
     return fs, p
 
 def load_melb_wallpressure(path, var_name="wall_pressure_fluc_Pa"):
     """Load frequency and pressure from a .mat file."""
     data = sio.loadmat(path)
     print(data.keys())
-    fs = np.ravel(data.get("fs_pressure_fluc_Pa", data.get("fs", None)))
-    p  = np.ravel(data.get(var_name))
+    fs = torch.tensor(data.get("fs_pressure_fluc_Pa", data.get("fs", None))).ravel()
+    p  = torch.tensor(data.get(var_name)).ravel()
     return fs, p

--- a/src/processing.py
+++ b/src/processing.py
@@ -1,4 +1,4 @@
-import numpy as np
+import torch
 import scipy.io as sio
 from scipy.signal import welch, find_peaks, peak_widths, csd, iirnotch, filtfilt
 from icecream import ic
@@ -10,8 +10,13 @@ def compute_psd(signal, fs, nperseg=None, noverlap=None):
         nperseg = len(signal) // 2000
     if noverlap is None:
         noverlap = nperseg // 2
-    return welch(signal, fs=fs, window="hann",
-                 nperseg=nperseg, noverlap=noverlap)
+    if torch.is_tensor(signal):
+        signal_np = signal.detach().cpu().numpy()
+    else:
+        signal_np = signal
+    f, pxx = welch(signal_np, fs=fs, window="hann",
+                   nperseg=nperseg, noverlap=noverlap)
+    return torch.tensor(f), torch.tensor(pxx)
 
 def compute_csd(signal1, signal2, fs, nperseg=None, noverlap=None):
     """One-sided PSD via Welch."""
@@ -19,8 +24,17 @@ def compute_csd(signal1, signal2, fs, nperseg=None, noverlap=None):
         nperseg = len(signal1) // 2000
     if noverlap is None:
         noverlap = nperseg // 2
-    return csd(signal1, signal2, fs=fs, window="hann",
+    if torch.is_tensor(signal1):
+        sig1_np = signal1.detach().cpu().numpy()
+    else:
+        sig1_np = signal1
+    if torch.is_tensor(signal2):
+        sig2_np = signal2.detach().cpu().numpy()
+    else:
+        sig2_np = signal2
+    f, Pxy = csd(sig1_np, sig2_np, fs=fs, window="hann",
                  nperseg=nperseg, noverlap=noverlap)
+    return torch.tensor(f), torch.tensor(Pxy)
 
 def propagate_frequency_error(f_duct, nu0, u_tau0, err_frac):
     """Compute nominal and ±error bounds for f_duct"""
@@ -30,6 +44,12 @@ def propagate_frequency_error(f_duct, nu0, u_tau0, err_frac):
     f_nom = f_duct * nu0 / u_tau0**2
     f_min = f_duct * nu_min / u_tau_max**2
     f_max = f_duct * nu_max / u_tau_min**2
+    if not torch.is_tensor(f_nom):
+        f_nom = torch.tensor(f_nom)
+    if not torch.is_tensor(f_min):
+        f_min = torch.tensor(f_min)
+    if not torch.is_tensor(f_max):
+        f_max = torch.tensor(f_max)
 
     return f_nom, f_min, f_max
 
@@ -46,15 +66,21 @@ def propagate_PSD_error(f_raw, psd, nu0, rho0, u_tau0, err_frac):
     phi_nom = f_raw * psd / denom_nom
     phi_min = f_raw * psd / denom_min
     phi_max = f_raw * psd / denom_max
+    if not torch.is_tensor(phi_nom):
+        phi_nom = torch.tensor(phi_nom)
+    if not torch.is_tensor(phi_min):
+        phi_min = torch.tensor(phi_min)
+    if not torch.is_tensor(phi_max):
+        phi_max = torch.tensor(phi_max)
 
     return phi_nom, phi_min, phi_max
 
 def duct_mode_freq(U, c, m, n, l, W, H, L):
     """Physical duct-mode frequency (quarter-wave, closed-open)."""
     delta2 = c**2 - U**2
-    k_sq   = (m*np.pi/W)**2 + (n*np.pi/H)**2
-    kz_sq  = ((2*l+1)*np.pi/L)**2
-    return (1/(2*np.pi)) * np.sqrt(delta2*k_sq + delta2**2/(4*c**2)*kz_sq)
+    k_sq   = (m*torch.pi/W)**2 + (n*torch.pi/H)**2
+    kz_sq  = ((2*l+1)*torch.pi/L)**2
+    return (1/(2*torch.pi)) * torch.sqrt(delta2*k_sq + delta2**2/(4*c**2)*kz_sq)
 
 def compute_duct_modes(U, c, mode_m, mode_n, mode_l, W, H, L, nu0, u_tau0, err_frac):
     """Compute non-dimensional duct modes (nom, min, max)."""
@@ -65,41 +91,57 @@ def compute_duct_modes(U, c, mode_m, mode_n, mode_l, W, H, L, nu0, u_tau0, err_f
         for n in mode_n:
             for l in mode_l:
                 f_phys = duct_mode_freq(U,c,m,n,l,W,H,L)
-                freqs["nom"].append(f_phys*nu0/u_tau0**2)
-                freqs["min"].append(f_phys*nu_min/u_tau_max**2)
-                freqs["max"].append(f_phys*nu_max/u_tau_min**2)
+                freqs["nom"].append(float(f_phys*nu0/u_tau0**2))
+                freqs["min"].append(float(f_phys*nu_min/u_tau_max**2))
+                freqs["max"].append(float(f_phys*nu_max/u_tau_min**2))
+    for k in freqs:
+        freqs[k] = torch.tensor(freqs[k])
     return freqs
 
 def notch_filter_fourier(f_nom, phi_nom, f_min, f_max, mode_freqs,
                  min_height=None, prominence=0.001, rel_height=0.9):
     """Notch out the largest PSD peak around each duct-mode."""
-    peaks, props = find_peaks(phi_nom, height=min_height, prominence=prominence)
+    if torch.is_tensor(phi_nom):
+        phi_nom_np = phi_nom.detach().cpu().numpy()
+        f_nom_np = f_nom.detach().cpu().numpy()
+        f_min_np = f_min.detach().cpu().numpy()
+        f_max_np = f_max.detach().cpu().numpy()
+    else:
+        phi_nom_np = phi_nom
+        f_nom_np = f_nom
+        f_min_np = f_min
+        f_max_np = f_max
+    peaks, props = find_peaks(phi_nom_np, height=min_height, prominence=prominence)
     if not peaks.size:
-        return phi_nom.copy(), []
-    widths, _, left_ips, right_ips = peak_widths(phi_nom, peaks, rel_height=rel_height)
-    idx = np.arange(len(f_nom))
-    phi_filt = phi_nom.copy()
+        return phi_nom.clone() if torch.is_tensor(phi_nom) else phi_nom.copy(), []
+    widths, _, left_ips, right_ips = peak_widths(phi_nom_np, peaks, rel_height=rel_height)
+    idx = np.arange(len(f_nom_np))
+    phi_filt_np = phi_nom_np.copy()
     info = []
-    for f0, fmin, fmax in zip(f_nom, f_min, f_max):
-        band = (f_nom >= fmin) & (f_nom <= fmax)
+    for f0, fmin, fmax in zip(f_nom_np, f_min_np, f_max_np):
+        band = (f_nom_np >= fmin) & (f_nom_np <= fmax)
         if not np.any(band):
             continue
-        low, high = f_nom[band][0], f_nom[band][-1]
-        in_band = peaks[(f_nom[peaks]>=low)&(f_nom[peaks]<=high)]
+        low, high = f_nom_np[band][0], f_nom_np[band][-1]
+        in_band = peaks[(f_nom_np[peaks]>=low)&(f_nom_np[peaks]<=high)]
         if not in_band.size:
             continue
-        pk = in_band[np.argmax(phi_nom[in_band])]
+        pk = in_band[np.argmax(phi_nom_np[in_band])]
         j = np.where(peaks==pk)[0][0]
-        fl = np.interp(left_ips[j], idx, f_nom)
-        fr = np.interp(right_ips[j], idx, f_nom)
-        info.append({"mode_freq":f0, "peak_freq":f_nom[pk], "f_left":fl, "f_right":fr})
-        mask = (f_nom>=fl)&(f_nom<=fr)
-        phi_filt[mask] = np.interp(
-            f_nom[mask],
+        fl = np.interp(left_ips[j], idx, f_nom_np)
+        fr = np.interp(right_ips[j], idx, f_nom_np)
+        info.append({"mode_freq":float(f0), "peak_freq":float(f_nom_np[pk]), "f_left":float(fl), "f_right":float(fr)})
+        mask = (f_nom_np>=fl)&(f_nom_np<=fr)
+        phi_filt_np[mask] = np.interp(
+            f_nom_np[mask],
             [fl, fr],
-            [phi_nom[int(np.floor(left_ips[j]))],
-             phi_nom[int(np.ceil (right_ips[j]))]]
+            [phi_nom_np[int(np.floor(left_ips[j]))],
+             phi_nom_np[int(np.ceil (right_ips[j]))]]
         )
+    if torch.is_tensor(phi_nom):
+        phi_filt = torch.tensor(phi_filt_np)
+    else:
+        phi_filt = phi_filt_np
     return phi_filt, info
 
 def notch_filter_timeseries(p, fs,
@@ -118,44 +160,57 @@ def notch_filter_timeseries(p, fs,
     noverlap = nperseg // 2
 
     # original PSD
-    f_nom, Pxx_nom = welch(p, fs=fs, nperseg=nperseg, noverlap=noverlap)
+    if torch.is_tensor(p):
+        p_np = p.detach().cpu().numpy()
+    else:
+        p_np = p
+    f_nom_np, Pxx_nom_np = welch(p_np, fs=fs, nperseg=nperseg, noverlap=noverlap)
+    f_nom = torch.tensor(f_nom_np)
+    Pxx_nom = torch.tensor(Pxx_nom_np)
 
     # find peaks
-    peaks, _ = find_peaks(Pxx_nom, height=min_height, prominence=prominence)
+    peaks, _ = find_peaks(Pxx_nom_np, height=min_height, prominence=prominence)
     if peaks.size == 0:
-        return p.copy(), (f_nom, Pxx_nom), (None, None), []
+        x_copy = p.clone() if torch.is_tensor(p) else p.copy()
+        return x_copy, (f_nom, Pxx_nom), (None, None), []
 
-    x_filt = p.copy()
+    x_filt = p.clone() if torch.is_tensor(p) else p.copy()
+    x_filt_np = x_filt.detach().cpu().numpy() if torch.is_tensor(x_filt) else x_filt
     info = []
 
-    for f0, fmin, fmax in zip(f_duct_nom, f_duct_min, f_duct_max):
-        mask = (f_nom >= fmin) & (f_nom <= fmax)
+    f_duct_nom_np = f_duct_nom.detach().cpu().numpy() if torch.is_tensor(f_duct_nom) else f_duct_nom
+    f_duct_min_np = f_duct_min.detach().cpu().numpy() if torch.is_tensor(f_duct_min) else f_duct_min
+    f_duct_max_np = f_duct_max.detach().cpu().numpy() if torch.is_tensor(f_duct_max) else f_duct_max
+    for f0, fmin, fmax in zip(f_duct_nom_np, f_duct_min_np, f_duct_max_np):
+        mask = (f_nom_np >= fmin) & (f_nom_np <= fmax)
         in_band = peaks[mask[peaks]]
         if in_band.size == 0:
             continue
 
         # pick largest peak
-        pk = in_band[np.argmax(Pxx_nom[in_band])]
-        widths, _, left_ips, right_ips = peak_widths(Pxx_nom, [pk], rel_height=rel_height)
-        fl = np.interp(left_ips[0], np.arange(len(f_nom)), f_nom)
-        fr = np.interp(right_ips[0], np.arange(len(f_nom)), f_nom)
+        pk = in_band[np.argmax(Pxx_nom_np[in_band])]
+        widths, _, left_ips, right_ips = peak_widths(Pxx_nom_np, [pk], rel_height=rel_height)
+        fl = np.interp(left_ips[0], np.arange(len(f_nom_np)), f_nom_np)
+        fr = np.interp(right_ips[0], np.arange(len(f_nom_np)), f_nom_np)
         bw = fr - fl
-        Q = f_nom[pk] / bw if bw > 0 else np.inf
+        Q = f_nom_np[pk] / bw if bw > 0 else np.inf
 
         # notch filter design
-        w0 = f_nom[pk] / (fs/2)
+        w0 = f_nom_np[pk] / (fs/2)
         b, a = iirnotch(w0, Q)
-        x_filt = filtfilt(b, a, x_filt)
+        x_filt_np = filtfilt(b, a, x_filt_np)
 
         info.append({
-            "mode_freq": f0,
-            "peak_freq": float(f_nom[pk]),
+            "mode_freq": float(f0),
+            "peak_freq": float(f_nom_np[pk]),
             "f_left": float(fl),
             "f_right": float(fr),
             "Q": float(Q)
         })
 
     # PSD of filtered signal
-    f_filt, Pxx_filt = welch(x_filt, fs=fs, nperseg=nperseg, noverlap=noverlap)
-
-    return x_filt, f_nom, Pxx_nom,f_filt, Pxx_filt, info
+    f_filt_np, Pxx_filt_np = welch(x_filt_np, fs=fs, nperseg=nperseg, noverlap=noverlap)
+    f_filt = torch.tensor(f_filt_np)
+    Pxx_filt = torch.tensor(Pxx_filt_np)
+    x_filt = torch.tensor(x_filt_np) if torch.is_tensor(p) else x_filt_np
+    return x_filt, f_nom, Pxx_nom, f_filt, Pxx_filt, info


### PR DESCRIPTION
## Summary
- convert numerical processing to use torch tensors
- adjust plotting functions to move tensors to CPU
- update processing helpers for torch
- add torch-based unit tests
- include torch dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*